### PR TITLE
propagate base host change to service level

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -38,6 +38,8 @@ export class AppRoot extends LitElement {
           <form @submit=${this.changeBaseHost}>
             <label>
               <span>Change Base Host</span>
+              <br />
+              <span>https://</span>
               <input />
             </label>
           </form>

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -1,15 +1,24 @@
 import { html, css, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
+import type { IaItemUserLists } from '../src/ia-item-user-lists';
 import '../src/ia-item-user-lists';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
-  // NOTE: we don't have a user to validate for the service
+  @property({ type: String }) itemId = 'goody';
+
+  @property({ type: String }) baseHost = 'archive.org';
+
+  @query('ia-item-user-lists') iaItemUserLists!: IaItemUserLists;
+
+  // NOTE: we don't have a usedr to validate for the service
   // so we expect pending, then error.
   render() {
     return html`
       <div>
         <ia-item-user-lists
+          item=${this.itemId}
+          .baseHost=${this.baseHost}
           @memberAdded=${(e: CustomEvent) =>
             console.log('memberAdded', e.detail)}
           @memberRemoved=${(e: CustomEvent) =>
@@ -23,7 +32,28 @@ export class AppRoot extends LitElement {
             console.log('selectDropdown', e.detail)}
         ></ia-item-user-lists>
       </div>
+      <br />
+      <section>
+        <div>
+          <form @submit=${this.changeBaseHost}>
+            <label>
+              <span>Change Base Host</span>
+              <input />
+            </label>
+          </form>
+        </div>
+      </section>
     `;
+  }
+
+  async changeBaseHost(e: Event) {
+    const form = e?.target as HTMLFormElement;
+    const newBaseHost = form?.querySelector('input')?.value as string;
+    console.log('changeBaseHost', { old: this.baseHost, new: newBaseHost });
+    this.baseHost = newBaseHost;
+    await this.iaItemUserLists.updateComplete;
+    console.log('userlistUpdated', this.iaItemUserLists.baseHost);
+    e.preventDefault();
   }
 
   static styles = css`

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
 
     body {
       background: #fafafa;
+      font-family: Arial, Helvetica, sans-serif;
     }
 
     body.modal-manager-open {

--- a/src/ia-item-user-lists.ts
+++ b/src/ia-item-user-lists.ts
@@ -1,7 +1,14 @@
 /**
  * Button and dropdown for adding item to user lists
  */
-import { html, css, LitElement, nothing, type TemplateResult } from 'lit';
+import {
+  html,
+  css,
+  LitElement,
+  nothing,
+  type TemplateResult,
+  PropertyValues,
+} from 'lit';
 import { property, customElement, state, query } from 'lit/decorators.js';
 import { Task, TaskStatus, initialState } from '@lit/task';
 import type { IaDropdown } from '@internetarchive/ia-dropdown';
@@ -112,6 +119,21 @@ export class IaItemUserLists extends LitElement {
         })
       );
     });
+  }
+
+  updated(changed: PropertyValues): void {
+    if (changed.has('baseHost') && this.baseHost) {
+      if (changed.get('baseHost')) {
+        this.reloadService();
+      }
+    }
+  }
+
+  reloadService(): void {
+    this.userListsService = UserListsServiceFactory.create({
+      serviceUrl: this.baseHost,
+    });
+    this.dataActionTask.run(['load']);
   }
 
   // Tasks

--- a/src/ia-item-user-lists.ts
+++ b/src/ia-item-user-lists.ts
@@ -22,6 +22,9 @@ type DataAction = 'initial' | 'load';
 
 @customElement('ia-item-user-lists')
 export class IaItemUserLists extends LitElement {
+  // Base host for user lists service
+  @property({ type: String }) baseHost = 'archive.org';
+
   // Item identifier
   @property({ type: String }) item = '';
 
@@ -49,7 +52,7 @@ export class IaItemUserLists extends LitElement {
 
   // UserListsService
   @state() private userListsService: UserListsServiceInterface =
-    UserListsServiceFactory.create();
+    UserListsServiceFactory.create({ serviceUrl: this.baseHost });
 
   @query('ia-dropdown') private dropdown!: IaDropdown;
 

--- a/src/user-lists-service.ts
+++ b/src/user-lists-service.ts
@@ -12,12 +12,15 @@ export type { UserListsServiceInterface, UserList };
 // UserListsService creator (for easier testing)
 export const UserListsServiceFactory = {
   create(options: Record<string, unknown>): UserListsService {
-    const { serviceUrl } = options;
+    const { serviceUrl, serviceProtocol = 'https://' } = options;
+    const baseUrl = serviceUrl
+      ? `${serviceProtocol}${serviceUrl}`
+      : userListServiceUrl;
     return new UserListsService({
       fetchHandler: new FetchHandler(),
       searchService: SearchService.default,
       userService: new UserService(),
-      baseUrl: `${serviceUrl ?? userListServiceUrl}`,
+      baseUrl,
     });
   },
 };

--- a/src/user-lists-service.ts
+++ b/src/user-lists-service.ts
@@ -11,12 +11,13 @@ import { userListServiceUrl } from './user-lists-service-url';
 export type { UserListsServiceInterface, UserList };
 // UserListsService creator (for easier testing)
 export const UserListsServiceFactory = {
-  create(): UserListsService {
+  create(options: Record<string, unknown>): UserListsService {
+    const { serviceUrl } = options;
     return new UserListsService({
       fetchHandler: new FetchHandler(),
       searchService: SearchService.default,
       userService: new UserService(),
-      baseUrl: userListServiceUrl,
+      baseUrl: `${serviceUrl ?? userListServiceUrl}`,
     });
   },
 };

--- a/test/ia-item-user-lists.test.ts
+++ b/test/ia-item-user-lists.test.ts
@@ -77,4 +77,18 @@ describe('IAItemUserlists', () => {
     const label = el.shadowRoot?.querySelector('div.label')?.innerHTML;
     expect(label).to.contain('Load Error');
   });
+
+  it('propagates `baseHost` down to service', async () => {
+    const el = await fixture<IaItemUserLists>(
+      html`<ia-item-user-lists item="goody"></ia-item-user-lists>`
+    );
+
+    const reloadServiceSpy = sinon.spy(el, 'reloadService');
+
+    el.baseHost = 'example.com';
+
+    await el.updateComplete;
+
+    expect(reloadServiceSpy.callCount).to.equal(1);
+  });
 });


### PR DESCRIPTION
## Problem:
when we were adding statsd calls to the backend service, we could not test in the review app as the web component was version locked to production url.

## Solution:
propagate optional baseHost from top of web component down to service level


### Demo app testing (all calls will fail, open dev console to see)
- open page
- open dev console & clear console and network tabs
- refresh page
- ✅ note failed call to archive.org of a user's lists in network and console views
- submit new base host using new input field in demo view.
- ✅ note failed call to new base host of a user's lists in network and console views
<img width="400" alt="image" src="https://github.com/internetarchive/iaux-item-userlists/assets/7840857/2fb9ec84-6262-4e09-8d52-bda27c87d403">
