### PR TITLE
WEBDEV-6889 Make text of button unselectable

### DIFF
--- a/src/ia-item-user-lists.ts
+++ b/src/ia-item-user-lists.ts
@@ -341,6 +341,8 @@ export class IaItemUserLists extends LitElement {
 
     .action-bar-text {
       font-weight: normal;
+      -webkit-user-select: none;
+      user-select: none;
       --iconLabelFlexDirection: column;
       --iconLabelGutterWidth: 0;
       --iconWidth: 16px;


### PR DESCRIPTION
Adds `user-select: none` styles to the action bar button so that dragging a selection through the button does not select it.