### PR TITLE
WEBDEV-7130 Allow headers in fetch handler & upgrade lists service dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/ia-dropdown": "^1.3.10",
-    "@internetarchive/ia-userlist-settings": "^1.0.16",
+    "@internetarchive/ia-userlist-settings": "1.0.22-alpha.0",
     "@internetarchive/modal-manager": "^2.0.0",
-    "@internetarchive/search-service": "^1.3.2",
+    "@internetarchive/search-service": "^1.4.1",
     "@internetarchive/user-service": "^0.1.3",
     "@lit/task": "^1.0.0",
     "lit": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/ia-dropdown": "^1.3.10",
-    "@internetarchive/ia-userlist-settings": "1.0.22-alpha.0",
+    "@internetarchive/ia-userlist-settings": "^1.0.22",
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/search-service": "^1.4.1",
     "@internetarchive/user-service": "^0.1.3",

--- a/src/fetch-handler.ts
+++ b/src/fetch-handler.ts
@@ -6,12 +6,14 @@ export class FetchHandler {
       includeCredentials?: boolean;
       method?: string;
       body?: BodyInit;
+      headers?: HeadersInit;
     }
   ): Promise<T> {
     const requestInit: RequestInit = {};
     if (options?.includeCredentials) requestInit.credentials = 'include';
     if (options?.method) requestInit.method = options.method;
     if (options?.body) requestInit.body = options.body;
+    if (options?.headers) requestInit.headers = options.headers;
     const response = await fetch(url, requestInit);
     const json = await response.json();
     return json as T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,14 +227,14 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/ia-userlist-settings@^1.0.16":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.0.17.tgz#660c1fb0e066fd9fecabfdb3f214d84eec6b893b"
-  integrity sha512-8PBdV75ReNokDjwcG374V+KflAPMHnpJgMEQgzvSzak3nX59QMtWs5GimTC/Tg+i3EH5qV4NoEiyrCO6QARnew==
+"@internetarchive/ia-userlist-settings@1.0.22-alpha.0":
+  version "1.0.22-alpha.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.0.22-alpha.0.tgz#3d13a99163f830c650d486481db76b6389b6c29c"
+  integrity sha512-hnuw1a9JWKbEmEho+odYKUCkFrpaek2fJrjWbrvVleq9Qw417c3OJSJ1HGqUA141Adn1VL27OzsqVbzFlL6rUQ==
   dependencies:
-    "@internetarchive/modal-manager" "0.3.4"
+    "@internetarchive/modal-manager" "2.0.0"
     "@internetarchive/result-type" "^0.0.1"
-    "@internetarchive/search-service" "^1.3.2"
+    "@internetarchive/search-service" "^1.4.1"
     "@internetarchive/user-service" "^0.1.3"
     lit "^2.8.0"
 
@@ -259,19 +259,7 @@
   dependencies:
     lit "^2.0.2"
 
-"@internetarchive/modal-manager@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-0.3.4.tgz#53c657db37a628ee94b70bb782a348b5da8aea76"
-  integrity sha512-fcAxBPgcG4Q1thBNRI+FCiglgQTEMyMmzv7DZNpQiM5RAOvkQrsdlwpB4ewqO7KiyCGWBoSHGCL2pbiVMeaIPg==
-  dependencies:
-    "@internetarchive/ia-activity-indicator" "^0.0.4"
-    "@internetarchive/icon-close" "^1.3.4"
-    "@internetarchive/icon-ia-logo" "^1.3.4"
-    "@internetarchive/icon-user" "^1.3.4"
-    lit "^2.8.0"
-    throttle-debounce "^5.0.0"
-
-"@internetarchive/modal-manager@^2.0.0":
+"@internetarchive/modal-manager@2.0.0", "@internetarchive/modal-manager@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.0.tgz#7782297de0d6d91aa133ca852dc2a0dcb087a6cd"
   integrity sha512-LN/0bpP2DWHA9f7jWIbCBOZLMWeoBTY2Sab9M1/yo2V3bubKzhnE9Dn0Y+UoCItlwZr2gDCLEng6Jz2DMGmhfw==
@@ -288,10 +276,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.2.tgz#713b1172ee13b3e3f3c72c85eb37b7c5e27b2b53"
-  integrity sha512-FiGZ13QWreeKZQ9Cpfr2cy2i9t9NRFa7pQMwVA9y+fZZwY/PyoWlPQKQySAmnjv3OKrq1I9LdZUkZ9EP4LNhxw==
+"@internetarchive/search-service@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.4.1.tgz#c68e2d285066137b879d49009c34caf8cfa96437"
+  integrity sha512-csXL1ikZGROss2wxKyyKZpZx4STv7W+RN1/Dw8hh2Jvd1vKYJjVv/ah9P9CnG/QarStvZuVVGA1m2Rru6m3O2w==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,12 +227,12 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/ia-userlist-settings@1.0.22-alpha.0":
-  version "1.0.22-alpha.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.0.22-alpha.0.tgz#3d13a99163f830c650d486481db76b6389b6c29c"
-  integrity sha512-hnuw1a9JWKbEmEho+odYKUCkFrpaek2fJrjWbrvVleq9Qw417c3OJSJ1HGqUA141Adn1VL27OzsqVbzFlL6rUQ==
+"@internetarchive/ia-userlist-settings@^1.0.22":
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.0.22.tgz#1415474467e2f8a43649691166e28da99596befd"
+  integrity sha512-gj9Po8HJLO/GRq1rY+Ytgt/317M0sboxslzvaWjHtyy4VBT5PON5laGKMmguWmV0mSA5L7770qvSsNaCNp8jjQ==
   dependencies:
-    "@internetarchive/modal-manager" "2.0.0"
+    "@internetarchive/modal-manager" "^2.0.0"
     "@internetarchive/result-type" "^0.0.1"
     "@internetarchive/search-service" "^1.4.1"
     "@internetarchive/user-service" "^0.1.3"
@@ -259,7 +259,7 @@
   dependencies:
     lit "^2.0.2"
 
-"@internetarchive/modal-manager@2.0.0", "@internetarchive/modal-manager@^2.0.0":
+"@internetarchive/modal-manager@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.0.tgz#7782297de0d6d91aa133ca852dc2a0dcb087a6cd"
   integrity sha512-LN/0bpP2DWHA9f7jWIbCBOZLMWeoBTY2Sab9M1/yo2V3bubKzhnE9Dn0Y+UoCItlwZr2gDCLEng6Jz2DMGmhfw==


### PR DESCRIPTION
Allows headers to be customized in the fetch handler, and upgrades the user lists service & search service to latest versions.