### PR TITLE
WEBDEV-8379 Upgrade dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@internetarchive/ia-dropdown": "^1.3.10",
+    "@internetarchive/ia-dropdown": "^2.1.0",
     "@internetarchive/ia-userlist-settings": "^1.0.22",
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/search-service": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/ia-dropdown": "^2.1.0",
-    "@internetarchive/ia-userlist-settings": "^1.0.22",
+    "@internetarchive/ia-userlist-settings": "^1.1.2",
     "@internetarchive/modal-manager": "^2.0.0",
-    "@internetarchive/search-service": "^1.4.1",
+    "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/user-service": "^0.1.3",
     "@lit/task": "^1.0.0",
     "lit": "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,10 +208,15 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@internetarchive/field-parsers@^0.1.0", "@internetarchive/field-parsers@^0.1.4":
+"@internetarchive/field-parsers@^0.1.0":
   version "0.1.4"
   resolved "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-0.1.4.tgz"
   integrity sha512-J5nhMsIU91eXnfoApa6SE0PffPbwK1Cd3YTLX/HjgayzMbXVkQvfebfVKSaoPmzHRRttbtY3Sg9FjviCwBq6qg==
+
+"@internetarchive/field-parsers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/field-parsers/-/field-parsers-1.0.0.tgz#ee3d3efb280860018193c2c52d54ec784e9bb202"
+  integrity sha512-cbD0FtJOjzBm7exxFrzrkHnqbmalKbEXA4i7KrwhUGBojF/QTTLAvaIRXH/bfoiTyCh6YT1/E/mULAQPdB6yvQ==
 
 "@internetarchive/ia-activity-indicator@^0.0.4":
   version "0.0.4"
@@ -220,6 +225,13 @@
   dependencies:
     lit "^2.2.2"
 
+"@internetarchive/ia-activity-indicator@^0.0.6 || ^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-1.0.0.tgz#9067093c037f81b2ff05747324449876afbb9643"
+  integrity sha512-vBwWGDBb/vzB+jxwLFeOjzmwXWD+UjAqvQFTszwQ31hEMBBY0U+jgSgMDznt/3pb1e8ZcqtzsHRTvpKkzhoZsg==
+  dependencies:
+    lit "^2.8.0 || ^3.3.2"
+
 "@internetarchive/ia-dropdown@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-2.1.0.tgz#86b357ae7e4026da1e9d36d87e322f6d56d53db6"
@@ -227,16 +239,24 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/ia-userlist-settings@^1.0.22":
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.0.22.tgz#1415474467e2f8a43649691166e28da99596befd"
-  integrity sha512-gj9Po8HJLO/GRq1rY+Ytgt/317M0sboxslzvaWjHtyy4VBT5PON5laGKMmguWmV0mSA5L7770qvSsNaCNp8jjQ==
+"@internetarchive/ia-userlist-settings@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-userlist-settings/-/ia-userlist-settings-1.1.2.tgz#ecc77d46e0a721debdf4221af7c1c9ee10900569"
+  integrity sha512-8vXx34EQeqjB5HcX7y7iNJUBvG0z/ghkYO3PZMlVvvUtxcs6Trmgl6oojtw9IBytYCoYaUpF7fp9sYxrj+babg==
   dependencies:
-    "@internetarchive/modal-manager" "^2.0.0"
+    "@internetarchive/modal-manager" "^2.0.1"
     "@internetarchive/result-type" "^0.0.1"
-    "@internetarchive/search-service" "^1.4.1"
-    "@internetarchive/user-service" "^0.1.3"
+    "@internetarchive/search-service" "^2.5.1"
+    "@internetarchive/user-service" "^1.0.0"
     lit "^2.8.0"
+
+"@internetarchive/iaux-item-metadata@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/iaux-item-metadata/-/iaux-item-metadata-1.1.0.tgz#88d55db382db482720313d01df1a96e5e0bb72a1"
+  integrity sha512-yj92Cg2HmYUJcHcJPclXosomsvU4WGJJ2BzH4tNECDXVFaGtChIiUNUV9xTXbcxSSKNLTQdlMYLk7w+nWZrohQ==
+  dependencies:
+    "@internetarchive/field-parsers" "^1.0.0"
+    typescript-memoize "^1.1.1"
 
 "@internetarchive/icon-close@^1.3.4":
   version "1.3.4"
@@ -244,6 +264,13 @@
   integrity sha512-1pYEV64zRhK3eZEY7F7bxs+TMW2zZKB8vd7fhJgbJMEGdJAPRahSUYPdlEZFg6cNDC/WzbcfERgFSstdRkolDw==
   dependencies:
     lit "^2.0.2"
+
+"@internetarchive/icon-close@^1.4.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/icon-close/-/icon-close-1.4.1.tgz#ae4d81cbb6356f207631bae7bfa1d0848df7bf30"
+  integrity sha512-nN1rGfScGssGFpfEew4azsrsMyUJtkDWqUDlckJi31PtyQnbZqUmZ07UO3Aw+wZIo3cU1MHxb5VxDy3Rmr8QGA==
+  dependencies:
+    lit "^2.0.2 || ^3.0.0"
 
 "@internetarchive/icon-ia-logo@^1.3.4":
   version "1.3.4"
@@ -259,6 +286,13 @@
   dependencies:
     lit "^2.0.2"
 
+"@internetarchive/icon-user@^1.4.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/icon-user/-/icon-user-1.4.1.tgz#d3ef9509ce1f457cd83d9e6d87c8dc6c181f2ba5"
+  integrity sha512-xRlpX954+lLKjC++A+jpIutptHCmVMwLZI/WqOoAQoKfnCNKKvJ6Wcdq4bM/qUDt44Oj2VgP/gM6hSdWyljzEA==
+  dependencies:
+    lit "^2.0.2 || ^3.0.0"
+
 "@internetarchive/modal-manager@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.0.tgz#7782297de0d6d91aa133ca852dc2a0dcb087a6cd"
@@ -271,20 +305,30 @@
     lit "^2.8.0"
     throttle-debounce "^5.0.0"
 
+"@internetarchive/modal-manager@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.6.tgz#8d13fec07b2adfe4752733e12d39e888244ca8f4"
+  integrity sha512-PDEXz005tgjhKxrJLnd1sn8wn3DceEQqDluDhcn8+gxxhFKX714jyicKlbgvHzQOLtJYTdJjnNdmiyziF7ZIVA==
+  dependencies:
+    "@internetarchive/ia-activity-indicator" "^0.0.6 || ^1.0.0"
+    "@internetarchive/icon-close" "^1.4.0"
+    "@internetarchive/icon-user" "^1.4.0"
+    lit "^2.8.0 || ^3.3.2"
+    throttle-debounce "^5.0.2"
+
 "@internetarchive/result-type@^0.0.1":
   version "0.0.1"
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.4.1.tgz#c68e2d285066137b879d49009c34caf8cfa96437"
-  integrity sha512-csXL1ikZGROss2wxKyyKZpZx4STv7W+RN1/Dw8hh2Jvd1vKYJjVv/ah9P9CnG/QarStvZuVVGA1m2Rru6m3O2w==
+"@internetarchive/search-service@^2.5.1", "@internetarchive/search-service@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.1.tgz#669f162bdbfa61d5f476ad75fea2460f798ff4e0"
+  integrity sha512-XpZGTYM0ZRBI+LYWLrUYQMlK/3hpU005wqy0uboMZF+adPqhAAPwrKD8oJsgwTOidymBqxoDssv2YmK/0Rwxcw==
   dependencies:
-    "@internetarchive/field-parsers" "^0.1.4"
+    "@internetarchive/iaux-item-metadata" "^1.1.0"
     "@internetarchive/result-type" "^0.0.1"
-    decorator-cache-getter "^1.0.0"
-    typescript-memoize "^1.1.0"
+    typescript-memoize "^1.1.1"
 
 "@internetarchive/user-service@^0.1.3":
   version "0.1.3"
@@ -294,6 +338,15 @@
     "@internetarchive/field-parsers" "^0.1.0"
     "@internetarchive/result-type" "^0.0.1"
     cookiejs "^2.0.2"
+
+"@internetarchive/user-service@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/user-service/-/user-service-1.0.0.tgz#414473715a56eeff9f16350f8e8c340f8f265afb"
+  integrity sha512-PygsSMSQ6NPx3JtN7ahLkuwSgJLLNhCGdiVcdpVhuFTLGzo2pz9GtxovStsXVJpl7u2bKyAAWD2KtST90xZL5w==
+  dependencies:
+    "@internetarchive/field-parsers" "^1.0.0"
+    "@internetarchive/result-type" "^0.0.1"
+    typescript-cookie "^1.0.6"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -335,6 +388,11 @@
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz#353ce4a76c83fadec272ea5674ede767650762fd"
   integrity sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==
 
+"@lit-labs/ssr-dom-shim@^1.5.0":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz#3166900c0d481f03d6d4133686e0febf760d521d"
+  integrity sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==
+
 "@lit/reactive-element@^1.0.0 || ^2.0.0", "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
   version "1.6.0"
   resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.0.tgz"
@@ -348,6 +406,13 @@
   integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.2.0"
+
+"@lit/reactive-element@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.1.2.tgz#4c6af9042603c98e61ba90b294607904d51b61cb"
+  integrity sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.5.0"
 
 "@lit/task@^1.0.0":
   version "1.0.0"
@@ -1754,11 +1819,6 @@ debug@^3.1.0, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-decorator-cache-getter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/decorator-cache-getter/-/decorator-cache-getter-1.0.0.tgz"
-  integrity sha512-yB49c5qi0govRjpe18vutEkkKzosIt2XggYSs1Qyev1TJYTh2WmLgDp0dV6VJ/6yNBRlKG+qMG80Vy4Bg0mLJw==
 
 deep-equal@^2.0.5:
   version "2.1.0"
@@ -3635,6 +3695,15 @@ lit-element@^4.0.4:
     "@lit/reactive-element" "^2.0.4"
     lit-html "^3.1.2"
 
+lit-element@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.2.2.tgz#f74fcbfbea945eae5614ece22a674fa52ca3365b"
+  integrity sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.5.0"
+    "@lit/reactive-element" "^2.1.0"
+    lit-html "^3.3.0"
+
 "lit-html@^2.0.0 || ^3.0.0", lit-html@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.1.2.tgz#6655ce82367472de7680c62b1bcb0beb0e426fa1"
@@ -3646,6 +3715,13 @@ lit-html@^2.8.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz"
   integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit-html@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.3.2.tgz#4db11fdbf98fc8a0c5eabd9b1e7d088d3bb201a2"
+  integrity sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
@@ -3666,6 +3742,15 @@ lit@^2.0.2, lit@^2.2.2, lit@^2.8.0:
     "@lit/reactive-element" "^1.6.0"
     lit-element "^3.3.0"
     lit-html "^2.8.0"
+
+"lit@^2.0.2 || ^3.0.0", "lit@^2.8.0 || ^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.3.2.tgz#d9230ebbf237bfd3d2091bc0b56c576a470ac4d7"
+  integrity sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==
+  dependencies:
+    "@lit/reactive-element" "^2.1.0"
+    lit-element "^4.2.0"
+    lit-html "^3.3.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -5027,6 +5112,11 @@ throttle-debounce@^5.0.0:
   resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz"
   integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
 
+throttle-debounce@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.2.tgz#ec5549d84e053f043c9fd0f2a6dd892ff84456b1"
+  integrity sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==
+
 through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
@@ -5160,9 +5250,14 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript-memoize@^1.1.0:
+typescript-cookie@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/typescript-cookie/-/typescript-cookie-1.0.6.tgz#009b0665706b2cc856f796e76cf408a16ef011c5"
+  integrity sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==
+
+typescript-memoize@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
 typescript@^3.9.10, typescript@^3.9.5, typescript@^3.9.7:

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,10 +220,10 @@
   dependencies:
     lit "^2.2.2"
 
-"@internetarchive/ia-dropdown@^1.3.10":
-  version "1.3.10"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-1.3.10.tgz#873be0875787b06cacc9083708a8061281706f52"
-  integrity sha512-+xGgyfE0O4cV+w4rk61yA5av5KeSqCmojukp6ePbrluIYBIH2UCtfDcfCEQFVsnNSs8AesJOkUb0q3jaW0M4cQ==
+"@internetarchive/ia-dropdown@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-2.1.0.tgz#86b357ae7e4026da1e9d36d87e322f6d56d53db6"
+  integrity sha512-FL8g78+42SiXEP21z6TjFHYGNtnG/sI6NUlPfft9GTlzOhz4QA9THRooSqa6fXeuatMPwqH4fTGhz6inwvKQ6Q==
   dependencies:
     lit "^2.8.0"
 
@@ -4843,7 +4843,16 @@ streamx@^2.15.0:
     fast-fifo "^1.1.0"
     queue-tick "^1.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4895,7 +4904,14 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5401,7 +5417,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5414,6 +5430,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Upgrades dependencies to latest versions in order to match the versions used by other components on the details pages & avoid double-registration errors.